### PR TITLE
Add mermaid click link parsing during indexing

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
 mod markdown;
+mod mermaid;
 mod wikilink;
 
 pub use markdown::{build_markdown_link, extract_markdown_links};
+pub use mermaid::extract_mermaid_links;
 pub use wikilink::{extract_wikilinks, parse_wikilink};
 
 #[derive(Debug, Clone)]
@@ -29,6 +31,7 @@ pub struct Link {
 pub enum LinkType {
     Wiki,
     Markdown,
+    Mermaid,
 }
 
 impl LinkType {
@@ -36,6 +39,7 @@ impl LinkType {
         match self {
             LinkType::Wiki => "wikilink",
             LinkType::Markdown => "markdown",
+            LinkType::Mermaid => "mermaid",
         }
     }
 }
@@ -149,6 +153,7 @@ impl MarkdownParser {
     fn extract_links(content: &str) -> Vec<Link> {
         let mut links = extract_wikilinks(content);
         links.extend(extract_markdown_links(content));
+        links.extend(extract_mermaid_links(content));
         links
     }
 }
@@ -204,6 +209,7 @@ mod tests {
     fn test_link_type_as_str() {
         assert_eq!(LinkType::Wiki.as_str(), "wikilink");
         assert_eq!(LinkType::Markdown.as_str(), "markdown");
+        assert_eq!(LinkType::Mermaid.as_str(), "mermaid");
     }
 
     #[test]

--- a/src/parser/mermaid.rs
+++ b/src/parser/mermaid.rs
@@ -1,0 +1,85 @@
+use super::{build_markdown_link, Link, LinkType};
+
+pub fn extract_mermaid_links(content: &str) -> Vec<Link> {
+    let mut links = Vec::new();
+    let mut in_mermaid_block = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if let Some(fence_lang) = trimmed.strip_prefix("```") {
+            if in_mermaid_block {
+                in_mermaid_block = false;
+            } else if fence_lang.trim().to_lowercase().starts_with("mermaid") {
+                in_mermaid_block = true;
+            }
+            continue;
+        }
+
+        if !in_mermaid_block {
+            continue;
+        }
+
+        if let Some(target) = parse_click_href_target(trimmed) {
+            if let Some(mut link) = build_markdown_link("", target, false) {
+                link.link_type = LinkType::Mermaid;
+                links.push(link);
+            }
+        }
+    }
+
+    links
+}
+
+fn parse_click_href_target(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with("click ") {
+        return None;
+    }
+
+    let href_pos = trimmed.find("href")?;
+    let after_href = &trimmed[href_pos + 4..];
+    let start_quote = after_href.find('"')?;
+    let after_quote = &after_href[start_quote + 1..];
+    let end_quote = after_quote.find('"')?;
+    let target = after_quote[..end_quote].trim();
+    if target.is_empty() {
+        None
+    } else {
+        Some(target)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_mermaid_links_basic() {
+        let content = "```mermaid\nclick A href \"Target Note\"\n```";
+        let links = extract_mermaid_links(content);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].text, "Target Note");
+        assert_eq!(links[0].link_type, LinkType::Mermaid);
+    }
+
+    #[test]
+    fn test_extract_mermaid_links_ignores_non_mermaid() {
+        let content = "click A href \"Target\"\n```graph\nclick B href \"Other\"\n```";
+        let links = extract_mermaid_links(content);
+        assert!(links.is_empty());
+    }
+
+    #[test]
+    fn test_extract_mermaid_links_with_heading() {
+        let content = "```mermaid\nclick A href \"Note.md#Section\"\n```";
+        let links = extract_mermaid_links(content);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].text, "Note");
+        assert_eq!(links[0].heading_ref, Some("Section".to_string()));
+    }
+
+    #[test]
+    fn test_parse_click_href_target_handles_missing_quotes() {
+        assert_eq!(parse_click_href_target("click A href Target"), None);
+    }
+}


### PR DESCRIPTION
## Summary
- parse mermaid `click ... href "..."` statements inside mermaid code fences
- store parsed targets as mermaid link entries in the existing links table
- add unit tests for mermaid click extraction and LinkType string mapping

## Testing
- `make fmt-check` *(failed: `cargo` not available in the environment)*
- `make clippy-check` *(not run; `cargo` missing)*